### PR TITLE
fix: Height Synchronization and Transaction Handling

### DIFF
--- a/execution.go
+++ b/execution.go
@@ -112,6 +112,10 @@ func (c *EngineAPIExecutionClient) InitChain(ctx context.Context, genesisTime ti
 			return execution_types.Hash{}, 0, fmt.Errorf("failed to get genesis block: %w", err)
 		}
 
+		if height := header.Number.Uint64(); height != 0 {
+			return execution_types.Hash{}, 0, fmt.Errorf("expected genesis block (height 0), got height %d", height)
+		}
+
 		// Now prepare block 1 by setting forkchoice to genesis
 		genesisHash := header.Hash()
 		var forkchoiceResult engine.ForkChoiceResponse


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview
This PR addresses several issues with block height synchronization between Rollkit and Reth, as well as improving transaction handling in the execution client.

### Changes

#### Block Height and State Synchronization
- Handle height mismatch between Rollkit (starts at 1) and Reth (starts at 0)
- Properly initialize chain state by retrieving genesis block's state root from Reth
- Use genesis block hash for initial forkchoice update

#### Transaction Processing
- Track previous block hash for accurate forkchoice updates
- Handle duplicate transaction submissions gracefully
- Skip "already known" transaction errors when submitting to Reth's pool

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new field to track the last block's hash for improved blockchain management.
	- Enhanced transaction execution logic for better performance and error handling.
- **Bug Fixes**
	- Improved error handling during blockchain initialization and transaction submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->