### PR TITLE
feat: add max message size flag for gRPC server configuration

### DIFF
--- a/cmd/evm-middleware/commands/run.go
+++ b/cmd/evm-middleware/commands/run.go
@@ -23,6 +23,7 @@ var (
 	genesisHashHex string
 	ethURL         string
 	engineURL      string
+	maxMsgSize     int
 )
 
 func init() {
@@ -35,6 +36,7 @@ func init() {
 	runCmd.Flags().StringVar(&genesisHashHex, "genesis-hash", "0x8bf225d50da44f60dee1c4ee6f810fe5b44723c76ac765654b6692d50459f216", "Genesis hash of the EVM chain")
 	runCmd.Flags().StringVar(&ethURL, "eth-url", "http://127.0.0.1:8545", "URL of the ETH API exposed by EVM node")
 	runCmd.Flags().StringVar(&engineURL, "engine-url", "http://127.0.0.1:8551", "URL of the Engine API exposed by EVM node")
+	runCmd.Flags().IntVar(&maxMsgSize, "max-msg-size", 4*1024*1024, "Maximum message size for gRPC connections (in bytes)") // New flag for maxMsgSize
 
 	// Attach the `runCmd` to the root command
 	rootCmd.AddCommand(runCmd)
@@ -70,7 +72,10 @@ var runCmd = &cobra.Command{
 
 		log.Println("Starting GRPC server...")
 		server := grpcproxy.NewServer(evmClient, grpcproxy.DefaultConfig())
-		s := grpc.NewServer()
+		s := grpc.NewServer(
+			grpc.MaxRecvMsgSize(maxMsgSize), // Use the value from the flag
+			grpc.MaxSendMsgSize(maxMsgSize), // Use the value from the flag
+		)
 		pb.RegisterExecutionServiceServer(s, server)
 
 		wg := sync.WaitGroup{}


### PR DESCRIPTION

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

Introduce a `--max-msg-size` flag to configure the maximum gRPC message size for both receiving and sending. This enhances flexibility and prevents runtime issues with oversized messages by allowing customization through the command line. Defaults to 4MB if unspecified.


Resolves #31 

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a command-line option that lets users customize the maximum message size for gRPC connections, with a default of 4 MB. This allows for flexible adjustment of the server's message-handling capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->